### PR TITLE
consistent capitalisation

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -186,4 +186,4 @@
 [fetch]
         fsckobjects = true
 [receive]
-        fsckObjects = true
+        fsckobjects = true


### PR DESCRIPTION
the other options had `fsckobjects` as well, but other options are using camel case, maybe switch the other two?